### PR TITLE
出品者の名前を表示させる様修正

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -117,7 +117,8 @@
                 %tbody
                   %tr
                     %th 出品者
-                    %td hide
+                    %td 
+                      = @user.nickname
                   %tr
                     %th カテゴリー
                     %td
@@ -174,7 +175,8 @@
                 %tbody
                   %tr
                     %th 出品者
-                    %td hide
+                    %td 
+                      = @user.nickname
                   %tr
                     %th カテゴリー
                     %td


### PR DESCRIPTION
# What
出品者の名前をニックネームに変更



# Why
誰が出品したかがわかるため

https://gyazo.com/8688d5e1fff152149516a9e0d79ebe12
https://gyazo.com/2b9959843d8baabd1e5b57d8cbe10350